### PR TITLE
Feature/INREL-3803: Article recommendations in AMP articles (8.x-2.x dev-branch)

### DIFF
--- a/templates/node/node--article--amp-teaser-square-s-responsive.html.twig
+++ b/templates/node/node--article--amp-teaser-square-s-responsive.html.twig
@@ -1,0 +1,3 @@
+{% extends "@infinite/node/node--article--teaser-default-small.html.twig" %}
+
+{% set wrapper_classes = attributes.addClass('teaser-square-small') %}

--- a/templates/node/node--article--amp.html.twig
+++ b/templates/node/node--article--amp.html.twig
@@ -1,79 +1,81 @@
 {% extends "@infinite/node/node.html.twig" %}
 
-{%  set attributes = attributes.addClass('no-v-padding') %}
+{% set attributes = attributes.addClass('no-v-padding') %}
 
 {% block content_header %}
 
-    {% block article_header_blocks %}
-        {{ content.field_header_blocks }}
-    {% endblock %}
+  {% block article_header_blocks %}
+    {{ content.field_header_blocks }}
+  {% endblock %}
 
-    {% block sponsored %}
-        {% embed '@infinite/node/twig-block-sponsored.html.twig' %}
-        {% endembed %}
-    {% endblock %}
+  {% block sponsored %}
+    {% embed '@infinite/node/twig-block-sponsored.html.twig' %}
+    {% endembed %}
+  {% endblock %}
 
-    {% block article_title_blocks %}
-        {% if not has_spotlight_title %}
-            {% if has_header_block %}
-                <h2 class="title--article">{{ label }}</h2>
-            {% else %}
+  {% block article_title_blocks %}
+    {% if not has_spotlight_title %}
+      {% if has_header_block %}
+        <h2 class="title--article">{{ label }}</h2>
+      {% else %}
 
-                {% block article_title_h1_blocks %}
-                    <h1 class="title--article">{{ label }}</h1>
-                {% endblock %}
-
-            {% endif %}
-
-            {% block author_teaser_block %}
-                {{ author_teaser }}
-            {% endblock %}
-
-            {% block publisher_data_block %}
-            {% endblock %}
-
-        {% endif %}
-    {% endblock %}
-
-    <aside class="socials socials-bar socials-vertical-bar">
-        {% block socials_vertical_bar %}
-            {% embed '@infinite_amp/embeds/social_icons.html.twig' with {
-            'url': url,
-            'label': label,
-            'twitter_share_via': twitter_share_via,
-            'email_share_text': email_share_text,
-            'email_subject': email_subject,
-            'whatsapp_share_text': whatsapp_share_text,
-            } %}
-            {% endembed %}
+        {% block article_title_h1_blocks %}
+          <h1 class="title--article">{{ label }}</h1>
         {% endblock %}
-    </aside>
+
+      {% endif %}
+
+      {% block author_teaser_block %}
+        {{ author_teaser }}
+      {% endblock %}
+
+      {% block publisher_data_block %}
+      {% endblock %}
+
+    {% endif %}
+  {% endblock %}
+
+  <aside class="socials socials-bar socials-vertical-bar">
+    {% block socials_vertical_bar %}
+      {% embed '@infinite_amp/embeds/social_icons.html.twig' with {
+        'url': url,
+        'label': label,
+        'twitter_share_via': twitter_share_via,
+        'email_share_text': email_share_text,
+        'email_subject': email_subject,
+        'whatsapp_share_text': whatsapp_share_text,
+      } %}
+      {% endembed %}
+    {% endblock %}
+  </aside>
 {% endblock %}
 
 {% block content_body %}
-    {% if content.field_paragraphs['#items'] %}
-        {{ content.field_paragraphs }}
-    {% endif %}
-    {{ content.field_tags }}
-    {{ content.field_ivw }}
+  {% if content.field_paragraphs['#items'] %}
+    {{ content.field_paragraphs }}
+  {% endif %}
+  {{ content.field_tags }}
+  {{ content.field_ivw }}
 
-    {% block socials_horizontal_bar %}
-        <aside class="socials socials-bar socials-horizontal-bar item-content__block">
-            {% embed '@infinite_amp/embeds/social_icons.html.twig' with {
-            'content': content,
-            'url': url,
-            'label': label,
-            twitter_share_via: '',
-            whatsapp_share_text: 'I read this article and thought you might like it:',
-            email_share_text: 'I read this article and thought you might like it:',
-            email_subject: 'An article you might like:'
-            } %}
-            {% endembed %}
-        </aside>
-    {% endblock %}
+  {% block socials_horizontal_bar %}
+    <aside class="socials socials-bar socials-horizontal-bar item-content__block">
+      {% embed '@infinite_amp/embeds/social_icons.html.twig' with {
+        'content': content,
+        'url': url,
+        'label': label,
+        twitter_share_via: '',
+        whatsapp_share_text: 'I read this article and thought you might like it:',
+        email_share_text: 'I read this article and thought you might like it:',
+        email_subject: 'An article you might like:'
+      } %}
+      {% endembed %}
+    </aside>
+  {% endblock %}
 
-    {% block paragraph_recent_content %}
-        {{ drupal_view('paragraph_recent_content', 'amp_recent_content') }}
-    {% endblock %}
+  {% block paragraph_recent_content %}
+    <div class="amp-recent-content">
+      {{ drupal_view('paragraph_recent_content', 'amp_recent_content') }}
+    </div>
+  {% endblock %}
 
 {% endblock %}

--- a/templates/node/node--article--amp.html.twig
+++ b/templates/node/node--article--amp.html.twig
@@ -73,12 +73,7 @@
   {% endblock %}
 
   {% block paragraph_recent_content %}
-    <div class="amp-recent-content">
-      {% block paragraph_recent_content_headline %}
-        <div class="label">Weitere Artikel zum Thema</div>
-      {% endblock %}
-      {{ drupal_view('paragraph_recent_content', 'amp_recent_content') }}
-    </div>
+    {{ drupal_view('paragraph_recent_content', 'amp_recent_content') }}
   {% endblock %}
 
 {% endblock %}

--- a/templates/node/node--article--amp.html.twig
+++ b/templates/node/node--article--amp.html.twig
@@ -74,6 +74,9 @@
 
   {% block paragraph_recent_content %}
     <div class="amp-recent-content">
+      {% block paragraph_recent_content_headline %}
+        <div class="label">Weitere Artikel zum Thema</div>
+      {% endblock %}
       {{ drupal_view('paragraph_recent_content', 'amp_recent_content') }}
     </div>
   {% endblock %}

--- a/templates/node/node--article--amp.html.twig
+++ b/templates/node/node--article--amp.html.twig
@@ -72,4 +72,8 @@
         </aside>
     {% endblock %}
 
+    {% block paragraph_recent_content %}
+        {{ drupal_view('paragraph_recent_content', 'amp_recent_content') }}
+    {% endblock %}
+
 {% endblock %}

--- a/templates/views/views-view--paragraph-recent-content--amp-recent-content.html.twig
+++ b/templates/views/views-view--paragraph-recent-content--amp-recent-content.html.twig
@@ -1,0 +1,43 @@
+{{ title_prefix }}
+  {% if title %}
+    {{ title }}
+  {% endif %}
+
+  {% if header %}
+    {{ header }}
+  {% endif %}
+  {% if exposed %}
+    {{ exposed }}
+  {% endif %}
+  {% if attachment_before %}
+    {{ attachment_before }}
+  {% endif %}
+
+  {% if rows %}
+    <div class="amp-recent-content">
+      {% block paragraph_recent_content_headline %}
+        <div class="label">Weitere Artikel zum Thema</div>
+      {% endblock %}
+      {{ rows }}
+    </div>
+  {% elseif empty %}
+    {{ empty }}
+  {% endif %}
+
+  {% if pager %}
+    {{ pager }}
+  {% endif %}
+  {% if attachment_after %}
+    {{ attachment_after }}
+  {% endif %}
+  {% if more %}
+    {{ more }}
+  {% endif %}
+  {% if footer %}
+    {{ footer }}
+  {% endif %}
+  {% if feed_icons %}
+    {{ feed_icons }}
+  {% endif %}
+
+{{ title_suffix }}


### PR DESCRIPTION
**8.x-2.x-dev - Version for instyle only**

New template templates/node/node--article--amp-teaser-square-s-responsive.html.twig created as an extend to @infinite/node/node--article--teaser-default-small.html.twig with an own class teaser-square-small

Created new block with drupal-view-output of {{ drupal_view('paragraph_recent_content', 'amp_recent_content') }} after each article. So it is placed at the end of this template templates/node/node--article--amp.html.twig