### PR TITLE
INREL-4050: fixed cropped product names on AMP

### DIFF
--- a/sass/mixins/_mixins.products.scss
+++ b/sass/mixins/_mixins.products.scss
@@ -22,7 +22,7 @@
   }
 
   .text-headline {
-    height: $product__item-text-headline-height-mobile;
+    height: ($product__item-text-headline-size * $product__item-text-headline-line-height) * 2;
     overflow: hidden;
   }
 


### PR DESCRIPTION
## [INREL-4050](https://jira.burda.com/browse/INREL-4050) 
 - ecommerce sliders had cropped product names 
 - issue was caused due to a height constraint
## How to test:
 - add ecommerce slider paragraph
 - product title should always occupy two lines

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](http://programmer.97things.oreilly.com/wiki/index.php/The_Boy_Scout_Rule)
- [ ] I have documented the changes (where applicable)
