### PR TITLE
INREL-5099: Fix TWIG cache error for content teaser on AMP

### DIFF
--- a/templates/node/node--article--amp-teaser-default-small.html.twig
+++ b/templates/node/node--article--amp-teaser-default-small.html.twig
@@ -1,4 +1,40 @@
-{% extends "@infinite/node/node--article--teaser-default-small.html.twig" %}
+{% set wrapper_classes = [
+    'teaser', 'teaser--small', 'contextual-region'
+] %}
 
-{% block sponsored %}{% endblock %}
-{% block teaser_author %}{% endblock %}
+{% if content.field_smart_teaser_class is defined and content.field_smart_teaser_class is not empty %}
+    {% set smart_teaser_class = content.field_smart_teaser_class|render %}
+    {% set wrapper_classes = wrapper_classes|merge([smart_teaser_class]) %}
+{% endif %}
+
+{% set attributes = attributes.setAttribute('data-nid', nid) %}
+{% set attributes = attributes.setAttribute('data-internal-url', url) %}
+
+<article{{ attributes.addClass(wrapper_classes) }}>
+    <div class="teaser__img-container">
+        {% block teaser_img_container %}
+            {{ content.field_teaser_media }}
+        {% endblock %}
+    </div>
+
+    <div class="teaser__caption">
+
+        {% block teaser_caption_channel %}{% endblock %}
+
+        {% block sponsored %}{% endblock %}
+
+        {% block teaser_author %}{% endblock %}
+
+        {% block teaser_text_headline %}
+            <h4 class="teaser__title text-headline">
+                <a href="{{ url }}" target="_self">{{ label }}</a>
+            </h4>
+        {% endblock %}
+
+    </div>
+
+    {% if (show_contextual_links) %}
+        {{ title_suffix.contextual_links }}
+    {% endif %}
+
+</article>


### PR DESCRIPTION
Copied HTML from infinite theme TWIG file to infinite_amp theme and replace non-working TWIG extend.