### PR TITLE
INREL-7168: feat: implements `$product__item-text-headline-height-mobile--ecommerce-slider-amp`

### DIFF
--- a/sass/mixins/_mixins.products.scss
+++ b/sass/mixins/_mixins.products.scss
@@ -119,10 +119,6 @@
     margin-bottom: 0;
   }
 
-  .text-headline {
-    //overflow: hidden;
-  }
-
   .text-brand {
     overflow: hidden;
     display: block;
@@ -171,8 +167,9 @@
   }
 
   .text-headline {
+    height: $product__item-text-headline-height-mobile--ecommerce-slider-amp;
     margin-bottom: $product__item-text-headline-gap-bottom-mobile;
-    //height: $product__item-text-headline-height-mobile;
+    overflow: hidden;
   }
 
   .img-container {


### PR DESCRIPTION
## [INREL-7168](https://jira.burda.com/browse/INREL-7168) 
 - Constrains number of lines of text for product title on mobile in ecommerce sliders

## How to test:
 - https://backend.esquire.local/entertainment/musik/test?amp
 - set mobile viewport
 - ensure product title text is constrained to two lines

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](http://programmer.97things.oreilly.com/wiki/index.php/The_Boy_Scout_Rule)
- [ ] I have documented the changes (where applicable)
